### PR TITLE
docs: use macros for drawio images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 .history/
 *.code-workspace
 *.vsix
+
+# Python
+*.pyc

--- a/docs/design/node-diagram/index.md
+++ b/docs/design/node-diagram/index.md
@@ -10,4 +10,4 @@ TBD.
 
 ![Node diagram](overall-node-diagram-autoware-universe.drawio.svg)
 
-[Open in draw.io for fullscreen]({{ "latest/design/node-diagram/overall-node-diagram-autoware-universe.drawio.svg" | drawio }})
+[Open in draw.io for fullscreen]({{ "/design/node-diagram/overall-node-diagram-autoware-universe.drawio.svg" | drawio }})

--- a/docs/design/node-diagram/index.md
+++ b/docs/design/node-diagram/index.md
@@ -10,4 +10,4 @@ TBD.
 
 ![Node diagram](overall-node-diagram-autoware-universe.drawio.svg)
 
-[Open in draw.io for fullscreen](https://app.diagrams.net/?lightbox=1#Uhttps%3A%2F%2Ftier4.github.io%2Fautoware-documentation%2Flatest%2Fdesign%2Fnode-diagram%2Foverall-node-diagram-autoware-universe.drawio.svg)
+[Open in draw.io for fullscreen]({{ "latest/design/node-diagram/overall-node-diagram-autoware-universe.drawio.svg" | drawio }})

--- a/main.py
+++ b/main.py
@@ -1,0 +1,8 @@
+import urllib
+
+
+def define_env(env):
+    @env.filter
+    def drawio(image_path):
+        image_url = urllib.parse.quote(f"{env.conf['site_url']}{image_path}", "")
+        return f"https://app.diagrams.net/?lightbox=1#U{image_url}"


### PR DESCRIPTION
Use [mkdocs-macros-plugin](https://github.com/fralau/mkdocs_macros_plugin) for `drawio` images to be independent of the branch name and repository name.